### PR TITLE
Fix accidental global variable

### DIFF
--- a/script.js
+++ b/script.js
@@ -50,7 +50,7 @@ function hitColor(color){
 }
 
 function missedColor(wrongColor){
-    indexWrong=colorOptions.indexOf(wrongColor);
+    var indexWrong = colorOptions.indexOf(wrongColor);
     if((level==='easy' && indexWrong<3) || level==='hard'){
         fadeAway(indexWrong);
         tryAgain=true;


### PR DESCRIPTION
## Summary
- stop leaking `indexWrong` into the global scope by declaring it with `var`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684a5b8d7070832d82261e174444fb0f