### PR TITLE
Add Jest tests for shuffle function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Color Game
+
+This project is a simple color guessing game. Tests use [Jest](https://jestjs.io/).
+
+## Running Tests
+
+Install dependencies and run:
+
+```bash
+npm test
+```

--- a/__tests__/shuffle.test.js
+++ b/__tests__/shuffle.test.js
@@ -1,0 +1,12 @@
+const { shuffle } = require('../script');
+
+describe('shuffle', () => {
+  test('returns all elements and maintains length', () => {
+    const arr = [1, 2, 3, 4, 5];
+    const result = shuffle([...arr]);
+    expect(result).toHaveLength(arr.length);
+    arr.forEach(el => {
+      expect(result).toContain(el);
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "colorgame",
+  "version": "1.0.0",
+  "description": "",
+  "main": "script.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.6.1"
+  }
+}

--- a/script.js
+++ b/script.js
@@ -132,4 +132,9 @@ function shuffle(array) {
   
     return array;
 }
+
+// export for testing
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { shuffle };
+}
   


### PR DESCRIPTION
## Summary
- export `shuffle` for Node usage
- add Jest dev dependency and test script
- write shuffle test verifying length and contents
- document test command in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a5c2587bc832d8116e85247f2c076